### PR TITLE
Fix missing url for submodule segm_models

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,2 @@
+[submodule "segm_models"]
+	url = https://github.com/qubvel/segmentation_models.pytorch.git


### PR DESCRIPTION
**Problem Description**
There was the `.gitmodules` file missing in this repository which specifies the url of the submodule.
```
fatal: No url found for submodule path 'segm_models' in .gitmodules
```

Fixes https://github.com/aval-e/DeepLab4Avalanches/issues/1